### PR TITLE
Hardcode publications list

### DIFF
--- a/api/fetch.js
+++ b/api/fetch.js
@@ -8,6 +8,7 @@ const htmlToText = require("html-to-text")
 const { isEqual, omit } = require("lodash")
 
 const { runWithDB } = require("./util")
+const { sAndB } = require("./publications-available")
 
 const parseHtml = htmlString =>
   new Promise((resolve, reject) => {
@@ -26,8 +27,6 @@ const decodeEntities = text => new htmlEntities.AllHtmlEntities().decode(text)
 
 const fetchSAndB = async () => {
   console.info(`${new Date()} -- Begin S&B fetch.`)
-
-  const PUBLICATION_ID = "s-and-b"
 
   const fetchArticles = async (page, limit, attempts = 0) => {
     let response
@@ -134,7 +133,7 @@ const fetchSAndB = async () => {
 
         return {
           id: String(post.id),
-          publication: PUBLICATION_ID,
+          publication: sAndB.id,
           title: decodeEntities(post.title_plain).trim(),
           datePublished: new Date(post.date).getTime(),
           dateEdited: new Date(post.modified).getTime(),
@@ -183,7 +182,7 @@ const fetchSAndB = async () => {
                 .map(async fetchedArticle => {
                   const articleCursor = articlesCollection.find({
                     id: fetchedArticle.id,
-                    publication: PUBLICATION_ID
+                    publication: sAndB.id
                   })
                   if (await articleCursor.hasNext()) {
                     // Maybe update the article

--- a/api/publications-available.js
+++ b/api/publications-available.js
@@ -1,0 +1,6 @@
+exports.sAndB = {
+  id: "s-and-b",
+  name: "The Scarlet and Black"
+}
+
+exports.items = [exports.sAndB]

--- a/api/publications.js
+++ b/api/publications.js
@@ -101,7 +101,6 @@ module.exports = Router()
         }
       })
 
-      const publicationsCollection = db.collection("publications")
       const articlesCollection = db.collection("articles")
 
       /** @type {number} */ const pageSize = +request.query.pageSize || 10
@@ -117,13 +116,7 @@ module.exports = Router()
         }
       }
 
-      const publicationExists = await publicationsCollection
-        .find({
-          _id: publicationId
-        })
-        .hasNext()
-
-      if (!publicationExists) {
+      if (!publicationsAvailable.items.some(({ id }) => id === publicationId)) {
         throw new HTTPError(404, `No publication with id "${publicationId}".`)
       }
 
@@ -218,19 +211,12 @@ module.exports = Router()
         }
       })
 
-      const publicationsCollection = db.collection("publications")
       const articlesCollection = db.collection("articles")
 
       /** @type {string} */ const publicationId = request.params.publicationId
       /** @type {string} */ const articleId = request.params.articleId
 
-      const publicationExists = await publicationsCollection
-        .find({
-          _id: publicationId
-        })
-        .hasNext()
-
-      if (!publicationExists) {
+      if (!publicationsAvailable.items.some(({ id }) => id === publicationId)) {
         throw new HTTPError(404, `No publication with id "${publicationId}".`)
       }
 


### PR DESCRIPTION
Should be merged after #2.

* Use a hardcoded array of publications instead of a database.
* Switch from magic IDs to referencing the `publications-available.js` file in fetching code.